### PR TITLE
closes #6

### DIFF
--- a/test.html
+++ b/test.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en" test1='val1' test2="val='2'" test3='val="3"' test4="val = 4" test5=val5 test6=val""6>
-<head>
+<head words="testing one two three">
   <meta charset="utf-8" />
-  <link rel="stylesheet" href="test.css" />
-  <link rel="alternate" title="Feed" type="application/atom+xml" href="#" />
+  <link rel="stylesheet" href="test.css" hreflang="en" />
+  <link rel="alternate" title="Feed" type="application/atom+xml" href="#" hreflang="en-gb" />
 </head>
-<body>
+<body words="testing three four five">
   <h1>Contents</h1>
   <ol class="chapters">
     <li>Preface</li>
@@ -27,13 +27,13 @@
   </p>
   <ul class="contacts">
     <li id="/contacts/4711">
-      <a href="/contacts/4711">
+      <a href="/contacts/4711" hreflang="en-us">
         <span class="firstname">Jon</span>
         <span class="lastname">Moore</span>
       </a>
     </li>
     <li id="/contacts/4712">
-      <a href="/contacts/4712">
+      <a href="/contacts/4712" hreflang="english">
         <span class="firstname">Homer</span>
         <span class="lastname">Simpson</span>
       </a>

--- a/test.lua
+++ b/test.lua
@@ -60,6 +60,17 @@ select("[itemscope='']")
 select("[itemscope=]")
 select("[itemscope]")
 
+select("[itemscope][itemprop='address']")
+select("[itemscope][itemprop!='address']")
+select("[itemscope][itemprop!='adres']")
+select("[itemscope][itemprop!='']")
+select("[hreflang|='en']")
+select("[itemprop*='address']")
+select("[words~='two']")
+select("[words~='three']")
+select("[itemprop$='ion']")
+select("[hreflang^='en']")
+
 print("\nchapters")
 local sel, chapters = root("ol.chapters > li"), {}
 for e in pairs(sel) do


### PR DESCRIPTION
:not(), [att=val], [att!=val], [att|=val], [att*=val], [att~=val],
[att^=val], [att$=val]
Note that the selection is now returned as a simple Set, breaking the
abilty brought in by #8 and #9 tot :select() or () on the selection. Of
course, the elements in the returned Set are still ElementNodes that
can be selected upon.
