### PR TITLE
v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ All tree elements provide, apart from `:select` and `()`, the following accessor
 - `.deeperclasses` as `.deeperelements`, but keyed on class name
 
 ##Limitations
-- Attribute values in selector strings cannot contain any spaces, nor any of `#`, `.`, `[`, `]`, `:`, `(`, or `)`
+- Attribute values in selector strings cannot contain any spaces, nor any of `#`, `[`, `]`, `:`, `(`, or `)`
 - The spaces before and after the `>` in a `parent > child` relation are mandatory 
 - `<!` elements (including doctype, comments, and CDATA) are not parsed; markup within CDATA is *not* escaped
 - Textnodes are no separate tree elements; in `local root = htmlparser.parse("<p>line1<br />line2</p>")`, `root.nodes[1]:getcontent()` is `"line1<br />line2"`, while `root.nodes[1].nodes[1].name` is `"br"`

--- a/htmlparser-0.3.1-1.rockspec
+++ b/htmlparser-0.3.1-1.rockspec
@@ -1,0 +1,28 @@
+package = "htmlparser"
+version = "0.3.1-1"
+source = {
+  url = "git://github.com/wscherphof/lua-htmlparser.git",
+  branch = "v0.3.1"
+}
+description = {
+  summary = "Parse HTML text into a tree of elements with selectors",
+  detailed = [[
+    Call parse() to build up a tree of element nodes. Each node in the tree, including the root node that is returned by parse(), supports a basic set of jQuery-like selectors. Or you could walk the tree by hand.
+  ]],
+  homepage = "http://wscherphof.github.io/lua-htmlparser/",
+  license = "LGPL+"
+}
+dependencies = {
+  "lua >= 5.2",
+  "set >= 0.2",
+  "lunitx >= 0.6"
+}
+build = {
+  type = "builtin",
+  copy_directories = {"doc", "tst"},
+  modules = {
+    htmlparser = "src/htmlparser.lua",
+    ["htmlparser.ElementNode"] = "src/htmlparser/ElementNode.lua",
+    ["htmlparser.voidelements"] = "src/htmlparser/voidelements.lua"
+  }
+}


### PR DESCRIPTION
Releasing the fix allowing a `.` in attribute values in selector
strings (#30)
