### PR TITLE
Allow custom HTML5 tags to include hyphens.

### DIFF
--- a/src/htmlparser.lua
+++ b/src/htmlparser.lua
@@ -12,7 +12,7 @@ local function parse(text)
     local openstart, name
     openstart, tpos, name = string.find(root._text, 
       "<" ..     -- an uncaptured starting "<"
-      "(%w+)" .. -- name = the first word, directly following the "<"
+      "([%w-]+)" .. -- name = the first word, directly following the "<"
       "[^>]*>",  -- include, but not capture everything up to the next ">"
     tpos)
     if not name then break end
@@ -51,7 +51,7 @@ local function parse(text)
     local closeend = tpos
     while true do
       local closestart, closing, closename
-      closestart, closeend, closing, closename = string.find(root._text, "[^<]*<(/?)(%w+)", closeend)
+      closestart, closeend, closing, closename = string.find(root._text, "[^<]*<(/?)([%w-]+)", closeend)
       if not closing or closing == "" then break end
       tag = table.remove(opentags[closename] or {}) or tag -- kludges for the cases of closing void or non-opened tags
       closestart = string.find(root._text, "<", closestart)

--- a/tst/init.lua
+++ b/tst/init.lua
@@ -277,3 +277,14 @@ function test_order()
     assert_equal(i, tonumber(v.name), "notn order")
   end
 end
+
+function test_tagnames_with_hyphens()
+	local tree = htmlparser.parse([[
+		<tag-name id="9999">
+			<m id="10000"></m>
+		</tag-name>
+	]])
+	assert_equal(1, #tree.nodes, "top level")
+	assert_equal("tag-name", tree("#9999")[1].name, "#9999")
+	assert_equal("m", tree("#10000")[1].name, "#10000")
+end


### PR DESCRIPTION
I'm working on a lua project that consumes HTML5 with custom tags like this:
`
<tw-passagedata>
  Content
</tw-passagedata>
`
The parser currently stops at `<tw-`, but this small change to the tag pattern fixed it for us. Cheers!