### PR TITLE
Wrap a text node in to current or parent node

### DIFF
--- a/src/htmlparser.lua
+++ b/src/htmlparser.lua
@@ -124,9 +124,7 @@ local function parse(text)
 			closestart, closeend, closing, closename = root._text:find("[^<]*<(/?)([%w-]+)", closeend)
 
 			-- Feature: Wrap a text node in to current or parent node
-			-- 新特征: 封装一个纯文本到一个当前或者父节点里
-			-- TODO: &nbsp;... et. not handle yet, create a ElementNode function to handle them?
-			-- TODO: 一些特殊字符还没有处理, 考虑创建一个ElementNode实例方法处理特殊字符?
+			-- TODO: &nbsp; &#914; etc. did not handled yet, create a ElementNode function to handle them?
 			do
 				local textstart
 				textstart , textend, textcontent = root._text:find(">([^<]*)", closestart)

--- a/tst/init.lua
+++ b/tst/init.lua
@@ -288,11 +288,36 @@ function test_order()
   for i,v in pairs(n) do
     assert_equal(i, tonumber(v:getcontent()), "n order")
   end
-  local notn = tree(":not(n)")
+  local notn = tree(":not(n,text)")
   assert_equal(4, #notn, "notn")
   for i,v in pairs(notn) do
     assert_equal(i, tonumber(v.name), "notn order")
   end
+end
+
+function test_wrap_literals_text_to_textnodes()
+	local tree = htmlparser.parse([[
+	<1>
+		<n>1</n>
+		<2>
+		<n>2</n>
+		<n>3</n>
+			<3>
+				<n>4</n>
+				<n>5</n>
+				<n>6</n>
+				<4>
+					<n>7</n>
+					<n>8</n>
+					<n>9</n>
+					<n>10</n>
+				</4>
+			</3>
+		</2>
+	</1>
+	]])
+	local texts = tree("text")
+	assert_equal(10, #texts, "texts")
 end
 
 function test_tagnames_with_hyphens()


### PR DESCRIPTION
Feature: Wrap a text node in to current or parent node
新特征: 封装一个纯文本到一个当前或者父节点里
TODO: &amp;nbsp;... et. not handle yet, create a ElementNode function to
handle them?
TODO: 一些特殊字符还没有处理, 考虑创建一个ElementNode实例方法处理特殊字符?